### PR TITLE
Automatically update term when upload calendar

### DIFF
--- a/src/views/Upload.vue
+++ b/src/views/Upload.vue
@@ -138,7 +138,8 @@ export default {
       Promise.all([
         ref.child('modules').update(mods),
         ref.child('groups').update({ [label]: t.sections }),
-        ref.child('sections').child(t.term).update(t.schedules)
+        ref.child('sections').child(t.term).update(t.schedules),
+        ref.child('term').update(t.term.split('-'))
       ]).then(() => {
         this.$set(this.$root, 'selected', t.sections)
         this.sending = false

--- a/src/views/Upload.vue
+++ b/src/views/Upload.vue
@@ -22,7 +22,7 @@
                   </v-btn>
                 </v-flex>
                 <v-flex xs12 sm6>
-                  <v-btn block :href="GBL" :disabled="!clikd" @click.prevent>
+                  <v-btn block :href="GBL" target="_blank" :disabled="!clikd">
                     2. Right Click & Save
                     <v-icon right>file_download</v-icon>
                   </v-btn>
@@ -31,6 +31,7 @@
             </v-container>
           </v-card-text>
           <v-card-actions>
+            <v-btn :href="HELP" target="_blank">Help</v-btn>
             <v-spacer></v-spacer>
             <v-btn @click.native="step = 2">I have it</v-btn>
           </v-card-actions>
@@ -106,6 +107,7 @@ import parse from '@/plugins/timetable'
 
 const SAMS = 'https://sams.sutd.edu.sg/'
 const GBL = 'psc/CSPRD/EMPLOYEE/HRMS/c/SA_LEARNER_SERVICES.SSR_SSENRL_LIST.GBL'
+const HELP = 'https://github.com/huixiang01/guide_to_sutd_timetable/blob/master/README.md#uploading-your-timetable'
 
 export default {
   data () {
@@ -114,6 +116,7 @@ export default {
       snack: { show: false, text: '' },
       GBL: SAMS + GBL,
       SAMS,
+      HELP,
       sending: false,
       mobile: false,
       clikd: false,


### PR DESCRIPTION
This should fix the occasional term issue described in #12 #15 by automatically updating the `term` value in firebase when someone uploads a new calendar.

Although the MR also makes it possible for one corrupted upload to break the whole site:

1. this will not affect existing subscription
2. it can be easily fixed by uploading another calendar
3. the whole system is already based on the trust in users

The MR also added a `HELP` button on the upload page which points to https://github.com/huixiang01/guide_to_sutd_timetable/blob/master/README.md